### PR TITLE
Inverse calibration regression

### DIFF
--- a/R/maths_linearCalibration.R
+++ b/R/maths_linearCalibration.R
@@ -36,14 +36,16 @@ linearCalibrationSingleDataset <- function(dataset, config, block){
 getCalibInterceptAndSlope <- function(dataset, config, useBlock){
   
   trainingData <- getTrainingData(dataset, config, useBlock)
+
+  # params from inverse regression to have least noise on predictor variable
+
+  d18OModel <- lm(`d(18_16)Mean` ~ o18_True, data = trainingData)
+  d18OIntercept <- -1 * coef(d18OModel)[[1]] / coef(d18OModel)[[2]]
+  d18OSlope <- 1 / coef(d18OModel)[[2]]
   
-  d18OModel <- lm(o18_True ~ `d(18_16)Mean`, data = trainingData)
-  d18OIntercept <- coef(d18OModel)[[1]]
-  d18OSlope <- coef(d18OModel)[[2]]
-  
-  dDModel <- lm(H2_True ~ `d(D_H)Mean`, data = trainingData)
-  dDIntercept <- coef(dDModel)[[1]]
-  dDSlope <- coef(dDModel)[[2]]
+  dDModel <- lm(`d(D_H)Mean` ~ H2_True, data = trainingData)
+  dDIntercept <- -1 * coef(dDModel)[[1]] / coef(dDModel)[[2]]
+  dDSlope <- 1 / coef(dDModel)[[2]]
   
   list(
     d18O = list(intercept = d18OIntercept, slope = d18OSlope),

--- a/tests/testthat/testLinearCalibration.R
+++ b/tests/testthat/testLinearCalibration.R
@@ -3,39 +3,41 @@ library(tidyverse)
 
 context("Test simple calibration without drift correction")
 
+# In this data set, o18_True is calculated from d(18_16)Mean applying
+# a slope = 0.9 and an intercept = -2.
 dataset1 <- tribble(
   ~Line, ~`Identifier 1`, ~`Inj Nr`, ~`d(18_16)Mean`, ~block, ~`d(D_H)Mean`, ~o18_True, ~H2_True, ~useForCalibration,
   # -- / -------------- / -------- / -------------- / ----- / ------------ / -------- / ------- / ---------------
-   1,    "A",             1,         1.05,            1,      -5,            1,         -5,       TRUE,
-   2,    "A",             2,         1,               1,      -5,            1,         -5,       TRUE,
-   3,    "A",             3,         1.1,             1,      -5,            1,         -5,       TRUE,
-   4,    "C",             1,         2,               1,      4,             2,         4,        TRUE,
-   5,    "C",             2,         2.3,             1,      4,             2,         4,        TRUE,
-   6,    "C",             3,         2.05,            1,      4,             2,         4,        TRUE,
-   7,    "B",             1,         3,               1,      7,             3,         7,        TRUE,
-   8,    "B",             2,         3.1,             1,      7,             3,         7,        TRUE,
-   9,    "B",             3,         3,               1,      7,             3,         7,        TRUE
+   1,    "A",             1,         1,               1,      -5,            -1.1,      -5,       TRUE,
+   2,    "A",             2,         1,               1,      -5,            -1.1,      -5,       TRUE,
+   3,    "A",             3,         1,               1,      -5,            -1.1,      -5,       TRUE,
+   4,    "C",             1,         2,               1,      4,             -0.2,      4,        TRUE,
+   5,    "C",             2,         2,               1,      4,             -0.2,      4,        TRUE,
+   6,    "C",             3,         2,               1,      4,             -0.2,      4,        TRUE,
+   7,    "B",             1,         3,               1,      7,             0.7,       7,        TRUE,
+   8,    "B",             2,         3,               1,      7,             0.7,       7,        TRUE,
+   9,    "B",             3,         3,               1,      7,             0.7,       7,        TRUE
 )
 expected1 <- tribble(
   ~Line, ~`Identifier 1`, ~`Inj Nr`, ~`d(18_16)Mean`, ~block, ~`d(D_H)Mean`, ~o18_True, ~H2_True, ~useForCalibration,
   # -- / -------------- / -------- / -------------- / ----- / ------------ / -------- / ------- / ---------------
-  1,    "A",             1,         0.99,             1,      -5,            1,         -5,       TRUE,
-  2,    "A",             2,         0.94,             1,      -5,            1,         -5,       TRUE,
-  3,    "A",             3,         1.04,             1,      -5,            1,         -5,       TRUE,
-  4,    "C",             1,         1.93,             1,      4,             2,         4,        TRUE,
-  5,    "C",             2,         2.23,             1,      4,             2,         4,        TRUE,
-  6,    "C",             3,         1.98,             1,      4,             2,         4,        TRUE,
-  7,    "B",             1,         2.93,             1,      7,             3,         7,        TRUE,
-  8,    "B",             2,         3.03,             1,      7,             3,         7,        TRUE,
-  9,    "B",             3,         2.93,             1,      7,             3,         7,        TRUE
+  1,    "A",             1,         -1.1,             1,      -5,            -1.1,      -5,       TRUE,
+  2,    "A",             2,         -1.1,             1,      -5,            -1.1,      -5,       TRUE,
+  3,    "A",             3,         -1.1,             1,      -5,            -1.1,      -5,       TRUE,
+  4,    "C",             1,         -0.2,             1,      4,             -0.2,      4,        TRUE,
+  5,    "C",             2,         -0.2,             1,      4,             -0.2,      4,        TRUE,
+  6,    "C",             3,         -0.2,             1,      4,             -0.2,      4,        TRUE,
+  7,    "B",             1,         0.7,              1,      7,             0.7,       7,        TRUE,
+  8,    "B",             2,         0.7,              1,      7,             0.7,       7,        TRUE,
+  9,    "B",             3,         0.7,              1,      7,             0.7,       7,        TRUE
 )
 
 config <- list(use_memory_correction = TRUE, use_three_point_calibration = TRUE)
 
 test_that("test getCalibInterceptAndSlope", {
   
-  o18InterceptExpected <- -0.05801953
-  o18SlopeExpected <- 0.9958159
+  o18InterceptExpected <- -2.
+  o18SlopeExpected <- 0.9
   H2InterceptExpected <- 0
   H2SlopeExpected <- 1
   


### PR DESCRIPTION
For linear regressions, it is optimal to use the variable with the least independent error on the predictor variable x. The proposed changes adopt this for getting the calibration slope and intercept.