### PR TITLE
Calculate standard deviation of mean d-excess value from propagation of uncertainty.

### DIFF
--- a/R/helpers_accumulateMeasurementsForEachSample.R
+++ b/R/helpers_accumulateMeasurementsForEachSample.R
@@ -58,7 +58,8 @@ doAccumulate <- function(dataset){
               sd.O18 = sd(`d(18_16)Mean`),
               sd.H2 = sd(`d(D_H)Mean`),
               d.Excess = mean(dExcess),
-              sd.d.Excess = sd(dExcess),
+              sd.d.Excess =
+                  sqrt((sd(`d(D_H)Mean`))^2 + 64 * (sd(`d(18_16)Mean`)^2)),
               Line = min(Line))
 }
 

--- a/tests/testthat/testAccumulateMeasurementsForEachSample.R
+++ b/tests/testthat/testAccumulateMeasurementsForEachSample.R
@@ -22,17 +22,16 @@ test_that("mean values are correct", {
   expected1 <- tribble(
     ~Line, ~`Identifier 1`, ~`Identifier 2`, ~block, ~delta.O18, ~delta.H2, ~sd.O18, ~sd.H2, ~d.Excess, ~sd.d.Excess,
     # -- / -------------- / -------------- / ----- / --------- / -------- / ------ / ----- / -------  / -----------
-    1,     "C",             "x",             1,      2,          20,        1,       5,      20,        5,
-    2,     "A",             "y",             NA,     4.5,        0,         0.71,    0,      4.5,       0.71,
-    3,     "B",             "z",             2,      10,         -5,        1.41,    0.42,   10,        1.41,
-    4,     "C",             "x",             3,      -3,         0,         1.41,    2.83,   0,         2.83
+    1,     "C",             "x",             1,      2,          20,        1,       5,      20,        9.43,
+    2,     "A",             "y",             NA,     4.5,        0,         0.71,    0,      4.5,       5.66,
+    3,     "B",             "z",             2,      10,         -5,        1.41,    0.42,   10,        11.32,
+    4,     "C",             "x",             3,      -3,         0,         1.41,    2.83,   0,         11.66
   )
     
   actual <- accumulateMeasurementsForEachSample(list(df1 = dataset1), list(average_over_last_n_inj = "all"))
   actualRounded <- mutate_if(actual$df1, is.numeric, ~ round(., 2))
   
   expect_length(actual, 1)
-
   expect_equal(actualRounded, expected1)
 })
 
@@ -57,10 +56,10 @@ test_that("use only last 2 injections to calculate average", {
   expected1 <- tribble(
     ~Line, ~`Identifier 1`, ~`Identifier 2`, ~block, ~delta.O18, ~delta.H2, ~sd.O18, ~sd.H2, ~d.Excess, ~sd.d.Excess,
     # -- / -------------- / -------------- / ----- / --------- / -------- / ------ / ----- / -------  / -----------
-    1,     "C",             "x",             1,      2.5,        22.5,      0.71,    3.54,   22.5,      3.54,
-    2,     "A",             "y",             NA,     4.5,        0,         0.71,    0,      4.5,       0.71,
-    3,     "B",             "z",             2,      10,         -5,        1.41,    0.42,   10,        1.41,
-    4,     "C",             "x",             3,      -3,         0,         1.41,    2.83,   0,         2.83
+    1,     "C",             "x",             1,      2.5,        22.5,      0.71,    3.54,   22.5,      6.67,
+    2,     "A",             "y",             NA,     4.5,        0,         0.71,    0,      4.5,       5.66,
+    3,     "B",             "z",             2,      10,         -5,        1.41,    0.42,   10,        11.32,
+    4,     "C",             "x",             3,      -3,         0,         1.41,    2.83,   0,         11.66
   )
   
   actual <- accumulateMeasurementsForEachSample(list(df1 = dataset1), list(average_over_last_n_inj = "2"))


### PR DESCRIPTION
This is necessary since the quantity of d-excess is calculated from the mean values of d18O and dD, which both have a measurement uncertainty.