### PR TITLE
set control std in config

### DIFF
--- a/R/helpers_associateStandardsWithConfigInfo.R
+++ b/R/helpers_associateStandardsWithConfigInfo.R
@@ -14,7 +14,7 @@ library(tidyverse)
 #' @param config A named list. Needs to contain the component
 #'               'standards'; a named list with the components
 #'               'name', 'o18_True', 'H2_True', 'use_for_drift_correction',
-#'               and 'use_for_calibration'.
+#'               'use_for_calibration', and 'use_as_control_standard'.
 #'
 #' @return A named list of dataframes. The names are equal to the names
 #'         of the input 'datasets'.
@@ -31,7 +31,8 @@ associateStandardsWithConfigInfoForDataset <- function(dataset, config){
               o18_True = as.double(o18_True), 
               H2_True = as.double(H2_True),
               useForDriftCorr = as.logical(use_for_drift_correction),
-              useForCalibration = as.logical(use_for_calibration))
+              useForCalibration = as.logical(use_for_calibration),
+              useAsControlStandard = as.logical(use_as_control_standard))
   
   left_join(x = dataset, y = configAsTable)
 }

--- a/R/main_processData.R
+++ b/R/main_processData.R
@@ -17,7 +17,7 @@
 #'                   $use_memory_correction (logical)
 #'                   $standards (named list of $name (character), $o18_True (numerical), 
 #'                               $H2_True (numerical), $use_for_drift_correction (logical), 
-#'                               $use_for_calibration (logical))
+#'                               $use_for_calibration (logical)), $use_as_control_standard(logical)
 #'
 #' @return A list of the same length as \code{datasets}. Each list element is
 #'   again a list of 13 elements with the following structure:

--- a/inst/extdata/config.yaml
+++ b/inst/extdata/config.yaml
@@ -19,23 +19,28 @@ standards:
     H2_True: -0.6
     use_for_drift_correction: no
     use_for_calibration: no
+    use_as_control_standard: no
   - name: DML
     o18_True: -42.50
     H2_True: -341.0
     use_for_drift_correction: yes
     use_for_calibration: yes
+    use_as_control_standard: no
   - name: TD1
     o18_True: -33.90
     H2_True: -266.2
     use_for_drift_correction: yes
     use_for_calibration: yes
+    use_as_control_standard: no
   - name: JASE
     o18_True: -50.22
     H2_True: -392.5
     use_for_drift_correction: yes
     use_for_calibration: yes
+    use_as_control_standard: no
   - name: NGT
     o18_True: -34.40
     H2_True: -265.5
     use_for_drift_correction: no
     use_for_calibration: no
+    use_as_control_standard: yes

--- a/tests/testthat/testAssociateStandardsWithConfigInfo.R
+++ b/tests/testthat/testAssociateStandardsWithConfigInfo.R
@@ -8,12 +8,14 @@ test_that("associating standards for single row (standard, including usage in ph
                                        o18_True = -2, 
                                        H2_True = 3,
                                        use_for_drift_correction = FALSE,
-                                       use_for_calibration = TRUE), 
+                                       use_for_calibration = TRUE,
+                                       use_as_control_standard = FALSE), 
                                   list(name = "STD_B", 
                                        o18_True = 1.8,
                                        H2_True = -0.4,
                                        use_for_drift_correction = TRUE,
-                                       use_for_calibration = TRUE)))
+                                       use_for_calibration = TRUE,
+                                       use_as_control_standard = TRUE)))
   df_1 <- tibble(
     `Identifier 1` = c("STD_A", "STD_B", "Probe", "STD_A"),
     val = 1:4
@@ -24,7 +26,8 @@ test_that("associating standards for single row (standard, including usage in ph
     o18_True = c(-2, 1.8, NA, -2),
     H2_True = c(3, -0.4, NA, 3),
     useForDriftCorr = c(F, T, NA, F),
-    useForCalibration = c(T, T, NA, T)
+    useForCalibration = c(T, T, NA, T),
+    useAsControlStandard = c(F, T, NA, F)
   )
   df_2 <- tibble(
     `Identifier 1` = c("xyz", "STD_B", "Probe", "STD_A"),
@@ -36,7 +39,8 @@ test_that("associating standards for single row (standard, including usage in ph
     o18_True = c(NA, 1.8, NA, -2),
     H2_True = c(NA, -0.4, NA, 3),
     useForDriftCorr = c(NA, T, NA, F),
-    useForCalibration = c(NA, T, NA, T)
+    useForCalibration = c(NA, T, NA, T),
+    useAsControlStandard = c(NA, T, NA, F)
   )
   
   dfActual <- associateStandardsWithConfigInfo(list(df_1, df_2), config)


### PR DESCRIPTION
closes #16 

The quality control standard must now be set in the config file. Each standard has the additional parameter `use_as_control_standard`. For example:

```yaml
standards:
  - name: KARA
    o18_True: -0.10
    H2_True: -0.6
    use_for_drift_correction: no
    use_for_calibration: no
    use_as_control_standard: no
  - ...
```

The output dataframe(s) of `associateStandardsWithConfigInfo` contain the additional column `useAsControlStandard`.

@thomas-muench If you agree with the changes proposed here, please merge the PR and delete this branch.