### PR TITLE
Add quality control output

### DIFF
--- a/R/helpers_accumulateMeasurementsForEachSample.R
+++ b/R/helpers_accumulateMeasurementsForEachSample.R
@@ -47,9 +47,16 @@ getQualityControlInfo <- function(dataset, accumulatedDataset) {
            useAsControlStandard) %>%
     drop_na()
 
+  deviationOfControlStandard <- deviationDataOfStandards %>%
+    filter(useAsControlStandard == TRUE) %>%
+    select(d18O = d18ODeviation, dD = dDDeviation) %>%
+    ungroup() %>%  # to remove grouping attributes
+    as.list()
+
   return(list(
     deviationsFromTrue = select(deviationDataOfStandards,
-                                -Line, -useAsControlStandard)
+                                -Line, -useAsControlStandard),
+    deviationOfControlStandard = deviationOfControlStandard
   ))
 
 }

--- a/R/helpers_accumulateMeasurementsForEachSample.R
+++ b/R/helpers_accumulateMeasurementsForEachSample.R
@@ -1,13 +1,12 @@
 library(tidyverse)
 
-#' accumulateMeasurementsForEachSample
+#' Process data for output
 #'
-#' Average the delta.O18, delta.H2 and d.Excess values for each 
-#' sample and calculate the standard deviation.
+#' Calculate the injection average of the samples and obtain the quality control
+#' information based on the true standard values.
 #' 
 #' Uses the config parameter 'average_over_last_n_inj'. If it is
-#' -1 or 'all', all injections are used to calculate the averages
-#' and standard deviations.
+#' -1 or 'all', all injections are used to calculate the sample averages.
 #'
 #' @param datasets A named list of data.frames
 #' @param config A named list. Needs to contain the component
@@ -16,18 +15,40 @@ library(tidyverse)
 #' @return A named list of data.frames. The list elements are named 
 #'         like the input list "datasets". 
 #'
-accumulateMeasurementsForEachSample <- function(datasets, config){
-  
-  map(datasets, accumulateMeasurementsForSingleDataset, config = config)
+processDataForOutput <- function(datasets, config) {
+
+  map(datasets, processSingleDatasetForOutput, config = config)
 }
 
+processSingleDatasetForOutput <- function(dataset, config) {
+
+  accumulatedData <- accumulateMeasurementsForSingleDataset(dataset, config)
+
+  return(accumulatedData)
+}
+
+#' accumulateMeasurementsForSingleDataset
+#'
+#' Average the delta.O18, delta.H2 and d.Excess values for each 
+#' sample from a dataset and calculate their standard deviation.
+#' 
+#' Uses the config parameter 'average_over_last_n_inj'. If it is
+#' -1 or 'all', all injections are used to calculate the averages
+#' and standard deviations.
+#'
+#' @param datasets A data frame with the data set.
+#' @param config A named list. Needs to contain the component
+#'               'average_over_last_n_inj'.
+#'
+#' @return A data frame.
+#'
 accumulateMeasurementsForSingleDataset <- function(dataset, config){
-    
+
   accumulatedData <- dataset %>%
     getLastNInjectionsForEachSample(config) %>%
     doAccumulate() %>% 
     rearrange()
-  
+
   return(accumulatedData)
 }
 

--- a/R/helpers_accumulateMeasurementsForEachSample.R
+++ b/R/helpers_accumulateMeasurementsForEachSample.R
@@ -24,7 +24,15 @@ processSingleDatasetForOutput <- function(dataset, config) {
 
   accumulatedData <- accumulateMeasurementsForSingleDataset(dataset, config)
 
-  return(accumulatedData)
+  qualityControlData <- getQualityControlInfo(dataset, accumulatedData)
+
+  return(
+    list(
+      accumulatedData = accumulatedData,
+      deviationsFromTrue = qualityControlData$deviationsFromTrue,
+      rmsdDeviationsFromTrue = qualityControlData$rmsdDeviationsFromTrue,
+      deviationOfControlStandard = qualityControlData$deviationOfControlStandard)
+  )
 }
 
 getQualityControlInfo <- function(dataset, accumulatedDataset) {
@@ -63,8 +71,8 @@ getQualityControlInfo <- function(dataset, accumulatedDataset) {
   return(list(
     deviationsFromTrue = select(deviationDataOfStandards,
                                 -Line, -useAsControlStandard),
-    deviationOfControlStandard = deviationOfControlStandard,
-    rmsdDeviationsFromTrue = rmsdDeviationDataOfStandards
+    rmsdDeviationsFromTrue = rmsdDeviationDataOfStandards,
+    deviationOfControlStandard = deviationOfControlStandard
   ))
 
 }

--- a/R/helpers_accumulateMeasurementsForEachSample.R
+++ b/R/helpers_accumulateMeasurementsForEachSample.R
@@ -78,8 +78,8 @@ getQualityControlInfo <- function(dataset, accumulatedDataset) {
 
   deviationOfControlStandard <- deviationDataOfStandards %>%
     filter(useAsControlStandard == TRUE) %>%
-    select(d18O = d18ODeviation, dD = dDDeviation) %>%
     ungroup() %>%  # to remove grouping attributes
+    select(d18O = d18ODeviation, dD = dDDeviation) %>%
     as.list()
 
   rmsdDeviationDataOfStandards <- deviationDataOfStandards %>%

--- a/R/helpers_accumulateMeasurementsForEachSample.R
+++ b/R/helpers_accumulateMeasurementsForEachSample.R
@@ -12,8 +12,10 @@ library(tidyverse)
 #' @param config A named list. Needs to contain the component
 #'               'average_over_last_n_inj'.
 #'
-#' @return A named list of data.frames. The list elements are named 
-#'         like the input list "datasets". 
+#' @return A named list of data.frames. The list elements are named like the
+#'   input list "datasets". Each list element is a list with the collected
+#'   output of \code{accumulateMeasurementsForSingleDataset()} and
+#'   \code{getQualityControlInfo().}
 #'
 processDataForOutput <- function(datasets, config) {
 
@@ -35,6 +37,25 @@ processSingleDatasetForOutput <- function(dataset, config) {
   )
 }
 
+#' Obtain quality control information
+#'
+#' Obtain the quality control information for a data set based on the deviations
+#' of the measured standards from their true values.
+#' 
+#' @param dataset a data frame with corrected and calibrated measurement data
+#' of a specific data set.
+#' @param accumulatedDataset a data frame with the accumulated
+#' (i.e. injection-averaged) measurement data for this data set.
+#' 
+#' @return A list with three elements:
+#'   $deviationsFromTrue (data frame with the deviations from the true value for
+#'    each measured standard.)
+#'   $rmsdDeviationsFromTrue (list with elements \code{d18O} and \code{dD} with
+#'    the rmsd across \code{deviationsFromTrue} (very first standard excluded).)
+#'   $deviationOfControlStandard (list with elements \code{Identifier 1},
+#'   \code{d18O} and \code{dD} with the deviations from the true value for the
+#'   quality control standard(s) in \code{Identifier 1}.) 
+#' 
 getQualityControlInfo <- function(dataset, accumulatedDataset) {
 
   infoDataOnStd <- dataset %>%

--- a/R/helpers_accumulateMeasurementsForEachSample.R
+++ b/R/helpers_accumulateMeasurementsForEachSample.R
@@ -53,10 +53,18 @@ getQualityControlInfo <- function(dataset, accumulatedDataset) {
     ungroup() %>%  # to remove grouping attributes
     as.list()
 
+  rmsdDeviationDataOfStandards <- deviationDataOfStandards %>%
+    filter(Line > 1) %>%  # do not use very first standard for rmsd calculation
+    ungroup() %>%
+    summarise(d18O = calculateRMSD(d18OMeasured, d18OTrue),
+              dD = calculateRMSD(dDMeasured, dDTrue)) %>%
+    as.list()
+
   return(list(
     deviationsFromTrue = select(deviationDataOfStandards,
                                 -Line, -useAsControlStandard),
-    deviationOfControlStandard = deviationOfControlStandard
+    deviationOfControlStandard = deviationOfControlStandard,
+    rmsdDeviationsFromTrue = rmsdDeviationDataOfStandards
   ))
 
 }

--- a/R/main_processData.R
+++ b/R/main_processData.R
@@ -112,8 +112,11 @@ processData <- function(datasets, config){
 
     output[[i]]$calibrated <- calibrated[[i]]
     output[[i]]$calibratedAndDriftCorrected <- calibratedDatasets[[i]]
-    output[[i]]$processed <- processedData[[i]]
+    output[[i]]$processed <- processedData[[i]]$accumulatedData
 
+    output[[i]]$deviationsFromTrue <- processedData[[i]]$deviationsFromTrue
+    output[[i]]$rmsdDeviationsFromTrue <- processedData[[i]]$rmsdDeviationsFromTrue
+    output[[i]]$deviationOfControlStandard <- processedData[[i]]$deviationOfControlStandard
     output[[i]]$pooledSD <- pooledStdDev[[i]]
     
   }
@@ -121,11 +124,5 @@ processData <- function(datasets, config){
   return(output)
 
 }
-    ## output[[i]]$calibrated <- NA
-    ## output[[i]]$calibratedAndDriftCorrected <- NA
-
-    ## output[[i]]$deviationsFromTrue <- NA
-    ## output[[i]]$rmsdDeviationsFromTrue <- NA
-    ## output[[i]]$deviationOfControlStandard <- NA
     ## output[[i]]$calibrationParams <- NA
     ## output[[i]]$driftParams <- NA

--- a/R/main_processData.R
+++ b/R/main_processData.R
@@ -92,7 +92,7 @@ processData <- function(datasets, config){
   calibratedDatasetsWithDExcess <- addColumnDExcess(calibratedDatasets)
   pooledStdDev <- calculatePoooledStdDev(calibratedDatasetsWithDExcess)
   
-  processedData <- accumulateMeasurementsForEachSample(
+  processedData <- processDataForOutput(
     calibratedDatasetsWithDExcess, config)
 
   # fill output structure

--- a/R/maths_calculateRMSD.R
+++ b/R/maths_calculateRMSD.R
@@ -1,0 +1,20 @@
+##' Root-mean-square deviation
+##'
+##' Calculate the root-mean-square deviation (rmsd) of two numeric vectors.
+##' @param v1 Numeric vector for which to compute the rmsd with \code{v2}.
+##' @param v2 Numeric vector for which to compute the rmsd with \code{v1}; must
+##' be of the same length as \code{v1}.
+##' @param na.rm a logical value indicating whether \code{NA} values should be
+##' stripped before the computation proceeds. Defaults to \code{FALSE}.
+##' @return The root-mean-square deviation of \code{v1} and \code{v2}, or
+##' \code{NA} (for \code{na.rm = FALSE}) if any of their elements is \code{NA}.
+calculateRMSD <- function(v1, v2, na.rm = FALSE) {
+
+    if (length(v1) != length(v2)) {
+        stop("Arguments must have the same length.")
+    }
+    res <- sqrt(mean((v1 - v2)^2, na.rm = na.rm))
+    
+    return(res)
+
+}

--- a/tests/testthat/testAccumulateMeasurementsForEachSample.R
+++ b/tests/testthat/testAccumulateMeasurementsForEachSample.R
@@ -27,10 +27,10 @@ test_that("mean values are correct", {
     4,     "C",             "x",             3,      -3,         0,         1.41,    2.83,   0,         11.66
   )
     
-  actual <- accumulateMeasurementsForEachSample(list(df1 = dataset1), list(average_over_last_n_inj = "all"))
-  actualRounded <- mutate_if(actual$df1, is.numeric, ~ round(., 2))
+  actual <- accumulateMeasurementsForSingleDataset(dataset1, list(average_over_last_n_inj = "all"))
+  actualRounded <- mutate_if(actual, is.numeric, ~ round(., 2))
   
-  expect_length(actual, 1)
+  expect_true(is.data.frame(actual))
   expect_equal(actualRounded, expected1)
 })
 
@@ -61,10 +61,10 @@ test_that("use only last 2 injections to calculate average", {
     4,     "C",             "x",             3,      -3,         0,         1.41,    2.83,   0,         11.66
   )
   
-  actual <- accumulateMeasurementsForEachSample(list(df1 = dataset1), list(average_over_last_n_inj = "2"))
-  actualRounded <- mutate_if(actual$df1, is.numeric, ~ round(., 2))
+  actual <- accumulateMeasurementsForSingleDataset(dataset1, list(average_over_last_n_inj = "2"))
+  actualRounded <- mutate_if(actual, is.numeric, ~ round(., 2))
   
-  expect_length(actual, 1)
+  expect_true(is.data.frame(actual))
   
   expect_equal(actualRounded, expected1)
 })

--- a/tests/testthat/testProcessData.R
+++ b/tests/testthat/testProcessData.R
@@ -47,6 +47,10 @@ test_that("check general output structure", {
   expect_true(is.list(actual[[1]]$pooledSD))
   expect_length(actual[[1]]$pooledSD, 2)
 
+  expect_true(is.data.frame(actual[[1]]$deviationsFromTrue))
+  expect_true(is.list(actual[[1]]$rmsdDeviationsFromTrue))
+  expect_true(is.list(actual[[1]]$deviationOfControlStandard))
+
   actual <- processData(datasets, config)
 
   expect_length(actual, 3)

--- a/tests/testthat/testProcessDataForOutput.R
+++ b/tests/testthat/testProcessDataForOutput.R
@@ -34,20 +34,19 @@ test_that("test quality control output structure", {
     "B",             3,      3,             3,         0,              29.75,       30,      0.25,
     "C",             3,      2.375,         2,         -0.375,         20.9,        20,      -0.9
     )
-  expected2 <- list(`Identifier 1` = "QC", d18O = -0.1, dD = 1.25)
+  expected2 <- list(d18O = -0.1, dD = 1.25)
   expected3 <- list(d18O = 0.194, dD = 0.836)
   
   accumulatedData <- accumulateMeasurementsForSingleDataset(
     dataset1, list(average_over_last_n_inj = "all"))
 
   actual <- getQualityControlInfo(dataset1, accumulatedData)
-
+  actualDeviationsFromTrue <- mutate_if(actual$deviationsFromTrue, is.numeric, round, digits = 5)
+  
   expect_length(actual, 3)
 
   expect_true(is.data.frame(actual$deviationsFromTrue))
-  ## TODO: expect_equal(actual$deviationsFromTrue, expected1)
-  expect_equal(nrow(actual$deviationsFromTrue), 5)
-  expect_equal(ncol(actual$deviationsFromTrue), 8)
+  expect_equal(actualDeviationsFromTrue, expected1)
 
   expect_true(is.list(actual$deviationOfControlStandard))
   expect_equal(actual$deviationOfControlStandard, expected2)

--- a/tests/testthat/testProcessDataForOutput.R
+++ b/tests/testthat/testProcessDataForOutput.R
@@ -37,12 +37,10 @@ test_that("test quality control output structure", {
   expected2 <- list(`Identifier 1` = "QC", d18O = -0.1, dD = 1.25)
   expected3 <- list(d18O = 0.194, dD = 0.836)
   
-  actual <- processDataForOutput(list(df1 = dataset1),
-                                 list(average_over_last_n_inj = "all"))
+  accumulatedData <- accumulateMeasurementsForSingleDataset(
+    dataset1, list(average_over_last_n_inj = "all"))
 
-  expect_length(actual, 1)
-
-  actual <- getQualityControlInfo(dataset1, actual$df1)
+  actual <- getQualityControlInfo(dataset1, accumulatedData)
 
   expect_length(actual, 3)
 
@@ -56,5 +54,10 @@ test_that("test quality control output structure", {
 
   expect_true(is.list(actual$rmsdDeviationsFromTrue))
   expect_equal(lapply(actual$rmsdDeviationsFromTrue, round, 3), expected3)
+
+  actual <- processDataForOutput(list(df1 = dataset1),
+                                 list(average_over_last_n_inj = "all"))
+  expect_length(actual, 1)
+  expect_length(actual$df1, 4)
   
 })

--- a/tests/testthat/testProcessDataForOutput.R
+++ b/tests/testthat/testProcessDataForOutput.R
@@ -1,0 +1,34 @@
+library(testthat)
+library(tidyverse)
+
+context("test ProcessDataForOutput")
+
+test_that("test output structure", {
+
+  dataset1 <- tribble(
+    ~Line, ~`Identifier 1`, ~`Identifier 2`, ~block, ~`Inj Nr`, ~`d(18_16)Mean`, ~`d(D_H)Mean`, ~dExcess, ~o18_True, ~H2_True, ~useAsControlStandard,
+    # -- / -------------- / -------------- / ----- / -------- / -------------- / ------------ / --------/ ---------/ --------/ ---------------------
+    1,     "WU",            "w",             1,      1,         0.9,             8.5,           15,       1,         10,       FALSE,
+    2,     "WU",            "w",             1,      2,         1,               9,             20,       1,         10,       FALSE,
+    3,     "WU",            "w",             1,      3,         1.1,             10.8,          25,       1,         10,       FALSE,
+    1,     "C",             "x",             1,      1,         1.9,             19,            15,       2,         20,       FALSE,
+    2,     "C",             "x",             1,      2,         2.1,             20.7,          20,       2,         20,       FALSE,
+    3,     "C",             "x",             1,      3,         2,               22.1,          25,       2,         20,       FALSE,
+    4,     "probe1",        "p",             NA,     1,         4,               49,            4,        5,         50,       FALSE,
+    5,     "probe1",        "p",             NA,     2,         5,               49,            5,        5,         50,       FALSE,
+    6,     "QC",            "qq",            2,      1,         10.4,            95,            11,       10,        100,      TRUE,
+    7,     "QC",            "qq",            2,      2,         9.8,             102.5,         9,        10,        100,      TRUE,
+    4,     "probe2",        "pp",            NA,     1,         6,               60,            4,        7,         70,       FALSE,
+    5,     "probe2",        "pp",            NA,     2,         7,               71,            5,        7,         70,       FALSE,
+    6,     "B",             "z",             3,      1,         2.8,             28.5,          11,       3,         30,       FALSE,
+    7,     "B",             "z",             3,      2,         3.2,             31,            9,        3,         30,       FALSE,
+    8,     "C",             "x",             3,      1,         -5.2,            -48.7,         -2,       -5,        -50,      FALSE,
+    9,     "C",             "x",             3,      2,         -5.3,            -50.4,         2,        -5,        -50,      FALSE
+  )
+
+  actual <- processDataForOutput(list(df1 = dataset1),
+                                 list(average_over_last_n_inj = "all"))
+
+  expect_length(actual, 1)
+  
+})

--- a/tests/testthat/testProcessDataForOutput.R
+++ b/tests/testthat/testProcessDataForOutput.R
@@ -35,6 +35,7 @@ test_that("test quality control output structure", {
     "C",             3,      2.375,         2,         -0.375,         20.9,        20,      -0.9
     )
   expected2 <- list(`Identifier 1` = "QC", d18O = -0.1, dD = 1.25)
+  expected3 <- list(d18O = 0.194, dD = 0.836)
   
   actual <- processDataForOutput(list(df1 = dataset1),
                                  list(average_over_last_n_inj = "all"))
@@ -43,7 +44,7 @@ test_that("test quality control output structure", {
 
   actual <- getQualityControlInfo(dataset1, actual$df1)
 
-  expect_length(actual, 2)
+  expect_length(actual, 3)
 
   expect_true(is.data.frame(actual$deviationsFromTrue))
   ## TODO: expect_equal(actual$deviationsFromTrue, expected1)
@@ -52,5 +53,8 @@ test_that("test quality control output structure", {
 
   expect_true(is.list(actual$deviationOfControlStandard))
   expect_equal(actual$deviationOfControlStandard, expected2)
+
+  expect_true(is.list(actual$rmsdDeviationsFromTrue))
+  expect_equal(lapply(actual$rmsdDeviationsFromTrue, round, 3), expected3)
   
 })

--- a/tests/testthat/testProcessDataForOutput.R
+++ b/tests/testthat/testProcessDataForOutput.R
@@ -34,17 +34,23 @@ test_that("test quality control output structure", {
     "B",             3,      3,             3,         0,              29.75,       30,      0.25,
     "C",             3,      2.375,         2,         -0.375,         20.9,        20,      -0.9
     )
+  expected2 <- list(`Identifier 1` = "QC", d18O = -0.1, dD = 1.25)
   
   actual <- processDataForOutput(list(df1 = dataset1),
                                  list(average_over_last_n_inj = "all"))
 
   expect_length(actual, 1)
 
-  actualQC <- getQualityControlInfo(dataset1, actual$df1)$deviationsFromTrue
+  actual <- getQualityControlInfo(dataset1, actual$df1)
 
-  expect_true(is.data.frame(actualQC))
-  ## TODO: expect_equal(actualQC, expected1)
-  expect_equal(nrow(actualQC), 5)
-  expect_equal(ncol(actualQC), 8)
+  expect_length(actual, 2)
+
+  expect_true(is.data.frame(actual$deviationsFromTrue))
+  ## TODO: expect_equal(actual$deviationsFromTrue, expected1)
+  expect_equal(nrow(actual$deviationsFromTrue), 5)
+  expect_equal(ncol(actual$deviationsFromTrue), 8)
+
+  expect_true(is.list(actual$deviationOfControlStandard))
+  expect_equal(actual$deviationOfControlStandard, expected2)
   
 })

--- a/tests/testthat/testProcessDataForOutput.R
+++ b/tests/testthat/testProcessDataForOutput.R
@@ -1,34 +1,50 @@
 library(testthat)
 library(tidyverse)
 
-context("test ProcessDataForOutput")
+context("test processDataForOutput")
 
-test_that("test output structure", {
+test_that("test quality control output structure", {
 
   dataset1 <- tribble(
     ~Line, ~`Identifier 1`, ~`Identifier 2`, ~block, ~`Inj Nr`, ~`d(18_16)Mean`, ~`d(D_H)Mean`, ~dExcess, ~o18_True, ~H2_True, ~useAsControlStandard,
     # -- / -------------- / -------------- / ----- / -------- / -------------- / ------------ / --------/ ---------/ --------/ ---------------------
     1,     "WU",            "w",             1,      1,         0.9,             8.5,           15,       1,         10,       FALSE,
     2,     "WU",            "w",             1,      2,         1,               9,             20,       1,         10,       FALSE,
-    3,     "WU",            "w",             1,      3,         1.1,             10.8,          25,       1,         10,       FALSE,
-    1,     "C",             "x",             1,      1,         1.9,             19,            15,       2,         20,       FALSE,
-    2,     "C",             "x",             1,      2,         2.1,             20.7,          20,       2,         20,       FALSE,
-    3,     "C",             "x",             1,      3,         2,               22.1,          25,       2,         20,       FALSE,
-    4,     "probe1",        "p",             NA,     1,         4,               49,            4,        5,         50,       FALSE,
-    5,     "probe1",        "p",             NA,     2,         5,               49,            5,        5,         50,       FALSE,
-    6,     "QC",            "qq",            2,      1,         10.4,            95,            11,       10,        100,      TRUE,
-    7,     "QC",            "qq",            2,      2,         9.8,             102.5,         9,        10,        100,      TRUE,
-    4,     "probe2",        "pp",            NA,     1,         6,               60,            4,        7,         70,       FALSE,
-    5,     "probe2",        "pp",            NA,     2,         7,               71,            5,        7,         70,       FALSE,
-    6,     "B",             "z",             3,      1,         2.8,             28.5,          11,       3,         30,       FALSE,
-    7,     "B",             "z",             3,      2,         3.2,             31,            9,        3,         30,       FALSE,
-    8,     "C",             "x",             3,      1,         -5.2,            -48.7,         -2,       -5,        -50,      FALSE,
-    9,     "C",             "x",             3,      2,         -5.3,            -50.4,         2,        -5,        -50,      FALSE
+    3,     "WU",            "w",             1,      3,         1.1,             10.7,          25,       1,         10,       FALSE,
+    4,     "C",             "x",             1,      1,         1.9,             19,            15,       2,         20,       FALSE,
+    5,     "C",             "x",             1,      2,         2.1,             20.7,          20,       2,         20,       FALSE,
+    6,     "C",             "x",             1,      3,         2,               22.1,          25,       2,         20,       FALSE,
+    7,     "probe1",        "p",             NA,     1,         4,               49,            4,        NA,        NA,       FALSE,
+    8,     "probe1",        "p",             NA,     2,         5,               49,            5,        NA,        NA,       FALSE,
+    9,     "QC",            "qq",            2,      1,         10.4,            95,            11,       10,        100,      TRUE,
+    10,    "QC",            "qq",            2,      2,         9.8,             102.5,         9,        10,        100,      TRUE,
+    11,    "probe2",        "pp",            NA,     1,         6,               60,            4,        NA,        NA,       FALSE,
+    12,    "probe2",        "pp",            NA,     2,         7,               71,            5,        NA,        NA,       FALSE,
+    13,    "B",             "z",             3,      1,         2.8,             28.5,          11,       3,         30,       FALSE,
+    14,    "B",             "z",             3,      2,         3.2,             31,            9,        3,         30,       FALSE,
+    15,    "C",             "x",             3,      1,         2.3,             19.1,           -2,       2,         20,      FALSE,
+    16,    "C",             "x",             3,      2,         2.45,            22.7,           2,        2,         20,      FALSE
   )
-
+  expected1 <- tribble(
+    ~`Identifier 1`, ~block, ~d18OMeasured, ~d18OTrue, ~d18ODeviation, ~dDMeasured, ~dDTrue, ~dDDeviation,
+    # -------------/ ------/ -------------/ ---------/ --------------/ -----------/ -------/ ------------
+    "WU",            1,      1,             1,         0,              9.4,         10,      0.6,
+    "C",             1,      2,             2,         0,              20.6,        20,      -0.6,
+    "QC",            2,      10.1,          10,        -0.1,           98.75,       100,     1.25,
+    "B",             3,      3,             3,         0,              29.75,       30,      0.25,
+    "C",             3,      2.375,         2,         -0.375,         20.9,        20,      -0.9
+    )
+  
   actual <- processDataForOutput(list(df1 = dataset1),
                                  list(average_over_last_n_inj = "all"))
 
   expect_length(actual, 1)
+
+  actualQC <- getQualityControlInfo(dataset1, actual$df1)$deviationsFromTrue
+
+  expect_true(is.data.frame(actualQC))
+  ## TODO: expect_equal(actualQC, expected1)
+  expect_equal(nrow(actualQC), 5)
+  expect_equal(ncol(actualQC), 8)
   
 })


### PR DESCRIPTION
This PR suggests changes to calculate and output quality control information for each data set based on evaluating the deviation of measured values of standards from their true values as specified in the input.

Specifically, it rewrites part of the code in `helpers_accumulateMeasurementsForEachSample.R` to deliver the desired output by replacing `accumulateMeasurementsForEachSample()` with `processDataForOutput()` and adding the functions `processSingleDatasetForOutput()` and `getQualityControlInfo()`. The code to deliver the programme output has been changed accordingly in `processData()`. Tests have been added to check the new behaviour. The new function `calculate RMSD()` in `maths_calculateRMSD.R` is used to obtain the root mean square deviation between two variables.

@twollnik Please have a look over the suggested changes. One specific point to look at is the test commented out in Line 48 of `testProcessDataForOutput.R`. From manual testing/printing I checked that the two data frames are actually identical, however, the automatic test still fails for reasons I coudn't figure out. If the test eventually works, it is supposed to replace the two tests in the following Lines 49-50 which only test for correct dimensions.