### PR TITLE
specify injection range

### DIFF
--- a/R/main_processData.R
+++ b/R/main_processData.R
@@ -11,7 +11,7 @@
 #' @param datasets A named list of data.frames. The isotope measurement data
 #'                 as output by the Picarro device.
 #' @param config A named list. Required fiels: 
-#'                   $average_over_last_n_inj (a number or "all")
+#'                   $average_over_inj (a number or "all")
 #'                   $use_three_point_calibration (logical)
 #'                   $calibration_method (1, 2, or 3)
 #'                   $use_memory_correction (logical)

--- a/inst/extdata/config.yaml
+++ b/inst/extdata/config.yaml
@@ -7,7 +7,9 @@ output_directory: tests/testthat/test_data/output # output directory for the cal
 include_standards_in_output:	yes	# format of desired csv-file output: flag=no->only output sample data/flag=yes->output standard and sample data in original order
 
 # -------- data processing options --------
-average_over_last_n_inj: all      # use the last n injections for each sample to calculate the mean d18O etc. To use all injections, pass "all".
+average_over_inj: 2               # Pass single number to use the last n injections for each sample to calculate the mean d18O etc. 
+                                  # Pass x:y to use injections x to y. E.g. 2:4 to use injections 2, 3, and 4.
+                                  # Pass "all" to use all injections.
 use_three_point_calibration: yes  # If yes, use three-point calibration. If no, use two-point calibration.
 calibration_method:	0		        	# set type of desired calibration: flag=1->drift-correction+three-point calibration/flag=2->double three-point calibration
 use_memory_correction:	yes			  # signal memory correction: yes/no

--- a/man/accumulateMeasurements.Rd
+++ b/man/accumulateMeasurements.Rd
@@ -8,7 +8,7 @@ accumulateMeasurements(dataset, config)
 }
 \arguments{
 \item{config}{A named list. Needs to contain the component
-'average_over_last_n_inj'.}
+'average_over_inj'.}
 
 \item{datasets}{A data frame with the data set.}
 }
@@ -20,7 +20,7 @@ Average the delta.O18, delta.H2 and d.Excess values for each
 sample from a dataset and calculate their standard deviation.
 }
 \details{
-Uses the config parameter 'average_over_last_n_inj'. If it is
+Uses the config parameter 'average_over_inj'. If it is
 -1 or 'all', all injections are used to calculate the averages
 and standard deviations.
 }

--- a/man/processData.Rd
+++ b/man/processData.Rd
@@ -11,7 +11,7 @@ processData(datasets, config)
 as output by the Picarro device.}
 
 \item{config}{A named list. Required fiels: 
-$average_over_last_n_inj (a number or "all")
+average_over_inj (a number or "all")
 $use_three_point_calibration (logical)
 $calibration_method (1, 2, or 3)
 $use_memory_correction (logical)

--- a/tests/testthat/testAccumulateMeasurementsForEachSample.R
+++ b/tests/testthat/testAccumulateMeasurementsForEachSample.R
@@ -27,7 +27,7 @@ test_that("mean values are correct", {
     4,     "C",             "x",             3,      -3,         0,         1.41,    2.83,   0,         11.66
   )
     
-  actual <- accumulateMeasurements(dataset1, list(average_over_last_n_inj = "all"))
+  actual <- accumulateMeasurements(dataset1, list(average_over_inj = "all"))
   actualRounded <- mutate_if(actual, is.numeric, ~ round(., 2))
   
   expect_true(is.data.frame(actual))
@@ -61,7 +61,42 @@ test_that("use only last 2 injections to calculate average", {
     4,     "C",             "x",             3,      -3,         0,         1.41,    2.83,   0,         11.66
   )
   
-  actual <- accumulateMeasurements(dataset1, list(average_over_last_n_inj = "2"))
+  actual <- accumulateMeasurements(dataset1, list(average_over_inj = "2"))
+  actualRounded <- mutate_if(actual, is.numeric, ~ round(., 2))
+  
+  expect_true(is.data.frame(actual))
+  
+  expect_equal(actualRounded, expected1)
+})
+
+test_that("use range of injections", {
+  
+  dataset1 <- tribble(
+    ~Line, ~`Identifier 1`, ~`Identifier 2`, ~block, ~`Inj Nr`, ~`d(18_16)Mean`, ~`d(D_H)Mean`, ~dExcess,
+    # -- / -------------- / -------------- / ----- / -------- / -------------- / ------------ / --------
+    1,     "C",             "x",             1,      2,         2,               20,            20,
+    2,     "C",             "x",             1,      3,         3,               25,            25,
+    3,     "C",             "x",             1,      1,         1000,            1000,          1000,
+    4,     "A",             "y",             NA,     3,         4,               0,             4,
+    5,     "A",             "y",             NA,     4,         5,               0,             5,
+    6,     "A",             "y",             NA,     2,         -100,            500,           100,
+    7,     "A",             "y",             NA,     1,         -100,            500,           100,
+    8,     "B",             "z",             2,      1,         11,              -5.3,          11,
+    9,     "B",             "z",             2,      2,         9,               -4.7,          9,
+    10,     "B",             "z",             2,      1,         99,              -100,          70,
+    11,     "C",             "x",             3,      1,         -2,              2,             -2,
+    12,     "C",             "x",             3,      2,         -4,              -2,            2
+  )
+  expected1 <- tribble(
+    ~Line, ~`Identifier 1`, ~`Identifier 2`, ~block, ~delta.O18, ~delta.H2, ~sd.O18, ~sd.H2, ~d.Excess, ~sd.d.Excess,
+    # -- / -------------- / -------------- / ----- / --------- / -------- / ------ / ----- / -------  / -----------
+    1,     "C",             "x",             1,      2.5,        22.5,      0.71,    3.54,   22.5,      6.67,
+    2,     "A",             "y",             NA,     4.5,        0,         0.71,    0,      4.5,       5.66,
+    3,     "B",             "z",             2,      10,         -5,        1.41,    0.42,   10,        11.32,
+    4,     "C",             "x",             3,      -3,         0,         1.41,    2.83,   0,         11.66
+  )
+  
+  actual <- accumulateMeasurements(dataset1, list(average_over_inj = "1:2"))
   actualRounded <- mutate_if(actual, is.numeric, ~ round(., 2))
   
   expect_true(is.data.frame(actual))

--- a/tests/testthat/testProcessDataForOutput.R
+++ b/tests/testthat/testProcessDataForOutput.R
@@ -37,7 +37,7 @@ test_that("test quality control output structure", {
   expected2 <- list(d18O = -0.1, dD = 1.25)
   expected3 <- list(d18O = 0.194, dD = 0.836)
   
-  actual1 <- accumulateMeasurements(dataset1, list(average_over_last_n_inj = "all"))
+  actual1 <- accumulateMeasurements(dataset1, list(average_over_inj = "all"))
   actual2 <- getQualityControlInfo(dataset1, actual1)
   
   expect_is(actual1, "data.frame")


### PR DESCRIPTION
Users can now specify an injection range e.g. 4:6 to use a specific set of injections. Config parameter `average_over_last_n_inj` renamed to `average_over_inj`.