### PR TITLE
Improve handling of memory coefficients

### DIFF
--- a/R/maths_correctForMemoryEffect.R
+++ b/R/maths_correctForMemoryEffect.R
@@ -49,7 +49,9 @@ calculateMemoryCoefficients <- function(dataset) {
 
   # remove all trailing rows from output dataframe which only contain NA values
   memCoeffOutput <- memCoeffOutput %>%
-    filter(cumall(!is.na(memoryCoeffD18O)))
+    arrange(desc(`Inj Nr`)) %>%
+    filter(cumany(!is.na(memoryCoeffD18O))) %>%
+    arrange(`Inj Nr`)
 
   # pad mean memory coefficients with 1's if last coefficient refers to an
   # injection number less than the maximum inj. number of the samples/standards

--- a/R/maths_correctForMemoryEffect.R
+++ b/R/maths_correctForMemoryEffect.R
@@ -50,6 +50,26 @@ calculateMemoryCoefficients <- function(dataset) {
   # remove all trailing rows from output dataframe which only contain NA values
   memCoeffOutput <- memCoeffOutput %>%
     filter(cumall(!is.na(memoryCoeffD18O)))
+
+  # pad mean memory coefficients with 1's if last coefficient refers to an
+  # injection number less than the maximum inj. number of the samples/standards
+  # in the other blocks
+
+  # bypass if only block 1 is passed as dataset
+  if (nrow(dataset) > nrow(filter(dataset, block == 1))) {
+
+    maxInjMeasurement <- max(
+      filter(dataset, is.na(dataset$block) | dataset$block != 1)$`Inj Nr`)
+    maxInjCoeff <- max(memCoeffOutput$`Inj Nr`)
+
+    if (maxInjMeasurement > maxInjCoeff) {
+
+      memCoeffOutput <- memCoeffOutput %>%
+        add_row(`Inj Nr` = (maxInjCoeff + 1) : maxInjMeasurement,
+                memoryCoeffD18O = rep(1, maxInjMeasurement - maxInjCoeff),
+                memoryCoeffDD = rep(1, maxInjMeasurement - maxInjCoeff))
+    }
+  }
   
   return(memCoeffOutput)
 }

--- a/R/maths_correctForMemoryEffect.R
+++ b/R/maths_correctForMemoryEffect.R
@@ -46,6 +46,10 @@ calculateMemoryCoefficients <- function(dataset) {
   # join the mean mem coeff and the mem coeff for each standard into one dataframe
   tablesToJoin <- append(memoryCoeffForEachStandard, list(meanMemoryCoefficients))
   memCoeffOutput <- reduce(tablesToJoin, full_join, by = "Inj Nr")
+
+  # remove all trailing rows from output dataframe which only contain NA values
+  memCoeffOutput <- memCoeffOutput %>%
+    filter(cumall(!is.na(memoryCoeffD18O)))
   
   return(memCoeffOutput)
 }

--- a/tests/testthat/testCorrectForMemoryEffect.R
+++ b/tests/testthat/testCorrectForMemoryEffect.R
@@ -255,7 +255,7 @@ test_that("test injection range of mean memory coefficients", {
 
 test_that("different numbers of injections for the block 1 standards does not cause error", {
   
-  dataset <- tribble(
+  dataset4 <- tribble(
     ~Line, ~`Identifier 1`, ~`Inj Nr`, ~`d(18_16)Mean`, ~block, ~`d(D_H)Mean`,
     # -- / -------------- / -------- / -------------- / ----- / -------------
     1,    "A",           1,         0.5,             1,      -5,
@@ -270,7 +270,54 @@ test_that("different numbers of injections for the block 1 standards does not ca
     10,   "B",           3,         3,               1,      0.0391
   )
   
-  actual <- correctForMemoryEffect(dataset)
+  actual <- correctForMemoryEffect(dataset4)
   
   expect_is(actual, "list")
 })
+
+# in this dataset:
+# d18O: m.tilde = 0.082085
+# dD: m.tilde = 0.2231302
+dataset5 <- tribble(
+  ~Line, ~`Identifier 1`, ~`Inj Nr`, ~`d(18_16)Mean`, ~block, ~`d(D_H)Mean`,
+  #--- / -------------- / -------- / -------------- / ----- / -------------
+  1,     "WU",            1,         -9.179,           1,    -62.145,
+  2,     "WU",            2,         -9.933,           1,    -76.017,
+  3,     "WU",            3,         -9.994,           1,    -79.111,
+  4,     "WU",            4,         -9.999,           1,    -79.802,
+  5,     "WU",            5,         -10,              1,    -79.956,
+  6,     "WU",            6,         -10,              1,    -79.990,
+  7,     "WU",            7,         -10,              1,    -79.998,
+  8,     "WU",            8,         -10,              1,    -79.999,
+  9,     "WU",            9,         -10,              1,    -80,
+  10,    "WU",            10,        -10,              1,    -80,
+  11,    "Std1",          1,         -28.358,          1,    -204.299,
+  12,    "Std1",          2,         -29.865,          1,    -232.034,
+  13,    "Std1",          3,         -29.989,          1,    -238.223,
+  14,    "Std1",          4,         -29.999,          1,    -239.603,
+  15,    "Std1",          5,         -30,              1,    -239.912,
+  16,    "Std1",          6,         -30,              1,    -239.980,
+  17,    "Std2",          1,         -39.179,          1,    -302.150,
+  18,    "Std2",          2,         -39.933,          1,    -316.017,
+  19,    "Std2",          3,         -39.994,          1,    -319.111,
+  20,    "Std2",          4,         -39.999,          1,    -319.802,
+  21,    "Std2",          5,         -40,              1,    -319.956,
+  22,    "Std2",          6,         -40,              1,    -319.990,
+  23,    "A",             1,         -35.410,          NA,   -288.923,
+  24,    "A",             2,         -35.034,          NA,   -281.992,
+  25,    "A",             3,         -35.003,          NA,   -280.444,
+  26,    "A",             4,         -35.,             NA,   -280.099,
+  27,    "A",             5,         -35.,             NA,   -280.022,
+  28,    "A",             6,         -35.,             NA,   -280.005,
+  29,    "A",             7,         -35.,             NA,   -280.001
+)
+
+test_that("test that no NA mean memory coefficients are produced", {
+
+  actual <- calculateMemoryCoefficients(dataset5)
+
+  expect_equal(nrow(actual), 6)
+  expect_equal(sum(is.na(c(actual$memoryCoeffD18O, actual$memoryCoeffDD))), 0)
+
+})
+  

--- a/tests/testthat/testCorrectForMemoryEffect.R
+++ b/tests/testthat/testCorrectForMemoryEffect.R
@@ -275,7 +275,7 @@ test_that("different numbers of injections for the block 1 standards does not ca
   expect_is(actual, "list")
 })
 
-# in this dataset:
+# in these datasets:
 # d18O: m.tilde = 0.082085
 # dD: m.tilde = 0.2231302
 dataset5 <- tribble(
@@ -310,6 +310,39 @@ dataset5 <- tribble(
   27,    "A",             5,         -35.,             NA,   -280.022,
   28,    "A",             6,         -35.,             NA,   -280.005
 )
+dataset6 <- tribble(
+  ~Line, ~`Identifier 1`, ~`Inj Nr`, ~`d(18_16)Mean`, ~block, ~`d(D_H)Mean`,
+  #--- / -------------- / -------- / -------------- / ----- / -------------
+  1,     "WU",            1,         -9.179,           1,    -62.145,
+  2,     "WU",            2,         -9.933,           1,    -76.017,
+  3,     "WU",            3,         -9.994,           1,    -79.111,
+  4,     "WU",            4,         -9.999,           1,    -79.802,
+  5,     "WU",            5,         -10,              1,    -79.956,
+  6,     "WU",            6,         -10,              1,    -79.990,
+  7,     "WU",            7,         -10,              1,    -79.998,
+  8,     "WU",            8,         -10,              1,    -79.999,
+  9,     "WU",            9,         -10,              1,    -80,
+  10,    "WU",            10,        -10,              1,    -80,
+  11,    "Std1",          1,         -28.358,          1,    -204.299,
+  12,    "Std1",          2,         -29.865,          1,    -232.034,
+  13,    "Std1",          3,         -29.989,          1,    -238.223,
+  14,    "Std1",          4,         -29.999,          1,    -239.603,
+  15,    "Std1",          5,         -30,              1,    -239.912,
+  16,    "Std1",          6,         -30,              1,    -239.980,
+  17,    "Std2",          1,         -39.179,          1,    -302.150,
+  18,    "Std2",          2,         -39.933,          1,    -316.017,
+  19,    "Std2",          3,         -39.994,          1,    -319.111,
+  20,    "Std2",          4,         -39.999,          1,    -319.802,
+  21,    "Std2",          5,         -40,              1,    -319.956,
+  22,    "Std2",          6,         -40,              1,    -319.990,
+  23,    "A",             1,         -35.410,          NA,   -288.923,
+  24,    "A",             2,         -35.034,          NA,   -281.992,
+  25,    "A",             3,         -35.003,          NA,   -280.444,
+  26,    "A",             4,         -35.,             NA,   -280.099,
+  27,    "A",             5,         -35.,             NA,   -280.022,
+  28,    "A",             6,         -35.,             NA,   -280.005,
+  29,    "A",             7,         -35.,             NA,   -280.001
+)
 
 test_that("test that no NA mean memory coefficients are kept", {
 
@@ -321,11 +354,6 @@ test_that("test that no NA mean memory coefficients are kept", {
 })
 
 test_that("test that number of memory coefficients fits sample data", {
-
-  dataset6 <- add_row(dataset5,
-                      Line = 29, `Identifier 1` = "A", `Inj Nr` = 7,
-                      `d(18_16)Mean` = -35., `d(D_H)Mean` = -280.001,
-                      block = NA)
 
   actualCoeff <- calculateMemoryCoefficients(dataset6)
   sampleData  <- filter(dataset6, is.na(dataset6$block))

--- a/tests/testthat/testCorrectForMemoryEffect.R
+++ b/tests/testthat/testCorrectForMemoryEffect.R
@@ -308,11 +308,10 @@ dataset5 <- tribble(
   25,    "A",             3,         -35.003,          NA,   -280.444,
   26,    "A",             4,         -35.,             NA,   -280.099,
   27,    "A",             5,         -35.,             NA,   -280.022,
-  28,    "A",             6,         -35.,             NA,   -280.005,
-  29,    "A",             7,         -35.,             NA,   -280.001
+  28,    "A",             6,         -35.,             NA,   -280.005
 )
 
-test_that("test that no NA mean memory coefficients are produced", {
+test_that("test that no NA mean memory coefficients are kept", {
 
   actual <- calculateMemoryCoefficients(dataset5)
 
@@ -320,4 +319,22 @@ test_that("test that no NA mean memory coefficients are produced", {
   expect_equal(sum(is.na(c(actual$memoryCoeffD18O, actual$memoryCoeffDD))), 0)
 
 })
+
+test_that("test that number of memory coefficients fits sample data", {
+
+  dataset6 <- add_row(dataset5,
+                      Line = 29, `Identifier 1` = "A", `Inj Nr` = 7,
+                      `d(18_16)Mean` = -35., `d(D_H)Mean` = -280.001,
+                      block = NA)
+
+  actualCoeff <- calculateMemoryCoefficients(dataset6)
+  sampleData  <- filter(dataset6, is.na(dataset6$block))
+
+  expect_equal(max(sampleData$`Inj Nr`), max(actualCoeff$`Inj Nr`))
+
+  actual <- correctForMemoryEffect(dataset6)$datasetMemoryCorrected
+  actual <- filter(actual, `Identifier 1` == "A")
+
+  expect_equal(sum(is.na(c(actual$`d(18_16)Mean`, actual$`d(D_H)Mean`))), 0)
   
+})

--- a/tests/testthat/testCorrectForMemoryEffect.R
+++ b/tests/testthat/testCorrectForMemoryEffect.R
@@ -353,16 +353,15 @@ test_that("test that no NA mean memory coefficients are kept", {
 
 })
 
-test_that("test that number of memory coefficients fits sample data", {
+test_that("test that no sample data is lost in memory correction", {
 
-  actualCoeff <- calculateMemoryCoefficients(dataset6)
-  sampleData  <- filter(dataset6, is.na(dataset6$block))
+  expect_error(actual <- correctForMemoryEffect(dataset6), NA)
 
-  expect_equal(max(sampleData$`Inj Nr`), max(actualCoeff$`Inj Nr`))
+  skip_if_not(exists("actual"), "previous test")
 
-  actual <- correctForMemoryEffect(dataset6)$datasetMemoryCorrected
-  actual <- filter(actual, `Identifier 1` == "A")
+  actual <- actual$datasetMemoryCorrected %>%
+    filter(`Identifier 1` == "A")
 
   expect_equal(sum(is.na(c(actual$`d(18_16)Mean`, actual$`d(D_H)Mean`))), 0)
-  
+
 })


### PR DESCRIPTION
This PR improves the handling of estimated memory coefficients by resolving two special cases:
1. If the very first standard in the first block has more injections than any other standard in this block, the resulting additional memory coefficients, being all NA, are removed from the data frame of memory coefficients to prevent error in the memory correction application.
2. If any normal sample or non-block1 standard is injected more often than estimated mean memory coefficients are available, the estimated mean coefficients are padded with 1 to ensure enough coefficients for all samples.

This closes #38 and #39.