### PR TITLE
Fix key retrieval error in Travis CI testing.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ r_packages:
   - covr
 
 script:
+  - apt-key adv --recv-key --keyserver keyserver.ubuntu.com C9A7585B49D51698710F3A115E25F516B04C661B
   - R CMD check .
 
 after_success:


### PR DESCRIPTION
This code change fixes the key retrieval error which has started to occur upon travis ci testing since Dec 2 2019 (or earliest Nov 30 2019).

@twollnik Should we merge this PR and do we have to permanently keep this fix?