### PR TITLE
Build package in travis ci test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,8 @@ r_packages:
 
 script:
   - apt-key adv --recv-key --keyserver keyserver.ubuntu.com C9A7585B49D51698710F3A115E25F516B04C661B
-  - R CMD check .
+  - R CMD build .
+  - R CMD check *tar.gz
 
 after_success:
   - Rscript -e 'covr::codecov()'


### PR DESCRIPTION
This PR changes the way Travis CI checks the package from using only R CMD check to R CMD build with a subsequent R CMD check on the generated tar file. This is the default way of doing it, and it will remove notes and warnings issued by the check which are only related to not checking on a tar file and to hidden files and directories.