### PR TITLE
Fix tibble and dplyr updates

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: piccr
 Title: Correct and Calibrate Picarro CRDS Stable Isotope Data
-Version: 1.1.0.9000
+Version: 1.1.1.9000
 Author: Thomas Muench [aut, cre],
     Tom Wollnik [aut]
 Maintainer: Thomas Muench <thomas.muench@awi.de>

--- a/R/helpers_smallFunctions.R
+++ b/R/helpers_smallFunctions.R
@@ -127,7 +127,7 @@ associateStandardsWithConfigInfo <- function(dataset, config){
 #' 
 groupStandardsInBlocks <- function(dataset, config){
     
-  dataset <- tibble::add_column(dataset, block = NA)
+  dataset <- tibble::add_column(dataset, block = NA_integer_)
   currBlock <- 0
   inBlock <- FALSE
   

--- a/R/helpers_smallFunctions.R
+++ b/R/helpers_smallFunctions.R
@@ -131,18 +131,26 @@ groupStandardsInBlocks <- function(dataset, config){
   currBlock <- 0
   inBlock <- FALSE
   
-  for(row in 1:nrow(dataset)){
-    id1 = dataset[row, "Identifier 1"]
-    if(isStandard(id1, config)){
-      if(inBlock){
-        dataset[row, "block"] <- currBlock
+  for (irow in 1 : nrow(dataset)) {
+
+    id1 <- dataset[irow, "Identifier 1"]
+
+    if (isStandard(id1, config)) {
+
+      if (inBlock) {
+
+        dataset[irow, "block"] <- currBlock
+
       } else {
+
         currBlock <- currBlock + 1
         inBlock <- TRUE
-        dataset[row, "block"] <- currBlock
+        dataset[irow, "block"] <- currBlock
       }
+
     } else {
-      dataset[row, "block"] <- NA
+
+      dataset[irow, "block"] <- NA
       inBlock <- FALSE
     }
   }

--- a/R/maths_correctForMemoryEffect.R
+++ b/R/maths_correctForMemoryEffect.R
@@ -76,7 +76,8 @@ calculateMemoryCoefficients <- function(dataset) {
     select(`Inj Nr`, `Identifier 1`, vial_group, memoryCoeffD18O, memoryCoeffDD)
 
   groupNames <- memoryCoeffForEachStandard %>%
-    group_keys(`Identifier 1`, `vial_group`) %>%
+    group_by(`Identifier 1`, `vial_group`) %>%
+    group_keys() %>%
     apply(1, function(x) {paste(x, collapse = "_vial")})
 
   memoryCoeffForEachStandard <- memoryCoeffForEachStandard %>%

--- a/R/maths_linearCalibration.R
+++ b/R/maths_linearCalibration.R
@@ -103,16 +103,18 @@ getTrainingData <- function(dataset, config, useBlock) {
   
   # if no memory correction is applied, use only the last three injections for calibration
   if (config$use_memory_correction == FALSE) {
-    trainingData <- trainingData %>% 
+    trainingData <- trainingData %>%
       group_by(`Identifier 1`, `vial_group`) %>%
-      slice((n()-2):n()) %>% 
-      ungroup()
+      slice((n() - 2) : n()) %>%
+      ungroup() %>%
+      arrange(Line)
   }
   
   # if two-point calibration is to be used, discard middle standards
   if (config$use_three_point_calibration == FALSE) {
     trainingData <- trainingData %>%
-      selectStandardsForTwoPointCalib()
+      selectStandardsForTwoPointCalib() %>%
+      arrange(Line)
   }
   
   return(trainingData)

--- a/tests/testthat/testAssignVialsToGroups.R
+++ b/tests/testthat/testAssignVialsToGroups.R
@@ -109,26 +109,24 @@ test_that("test that vial grouping yields proper injection numbers", {
   expected <- tibble::tribble(
     ~Line, ~`Identifier 1`, ~`Inj Nr`, ~`d(18_16)Mean`, ~`d(D_H)Mean`, ~block, ~vial_group,
     # -- / -------------- / -------- / -------------- / -------------/ ------/ ------------
-    1,     "STD_A",         1,         1,               1,             1,      1,
-    2,     "STD_A",         2,         1,               1,             1,      1,
-    3,     "STD_B",         1,         2,               2,             1,      1,
-    4,     "STD_B",         2,         2,               2,             1,      1,
-    5,     "STD_C",         1,         3,               3,             1,      1,
-    6,     "STD_C",         2,         3,               3,             1,      1,
-    7,     "STD_A",         1,         1,               1,             1,      2,
-    8,     "STD_A",         2,         1,               1,             1,      2,
-    9,     "STD_A",         3,         1,               1,             1,      2,
-    10,    "STD_A",         4,         1,               1,             1,      2,
-    11,    "PROBE_A",       1,         10,              10,            NA,     1,
-    12,    "PROBE_B",       1,         20,              20,            NA,     1,
-    13,    "PROBE_A",       1,         10,              10,            NA,     2,
-    14,    "STD_B",         1,         2,               2,             2,      2,
-    15,    "STD_B",         2,         2,               2,             2,      2,
-    16,    "STD_A",         1,         1,               1,             2,      3,
-    17,    "STD_A",         2,         1,               1,             2,      3
+    1,     "STD_A",         1L,        1,               1,             1L,     1,
+    2,     "STD_A",         2L,        1,               1,             1L,     1,
+    3,     "STD_B",         1L,        2,               2,             1L,     1,
+    4,     "STD_B",         2L,        2,               2,             1L,     1,
+    5,     "STD_C",         1L,        3,               3,             1L,     1,
+    6,     "STD_C",         2L,        3,               3,             1L,     1,
+    7,     "STD_A",         1L,        1,               1,             1L,     2,
+    8,     "STD_A",         2L,        1,               1,             1L,     2,
+    9,     "STD_A",         3L,        1,               1,             1L,     2,
+    10,    "STD_A",         4L,        1,               1,             1L,     2,
+    11,    "PROBE_A",       1L,        10,              10,            NA,     1,
+    12,    "PROBE_B",       1L,        20,              20,            NA,     1,
+    13,    "PROBE_A",       1L,        10,              10,            NA,     2,
+    14,    "STD_B",         1L,        2,               2,             2L,     2,
+    15,    "STD_B",         2L,        2,               2,             2L,     2,
+    16,    "STD_A",         1L,        1,               1,             2L,     3,
+    17,    "STD_A",         2L,        1,               1,             2L,     3
   )
-
-  expected$`Inj Nr` <- as.integer(expected$`Inj Nr`)
 
   actual <- dataset %>%
     groupStandardsInBlocks(config) %>%

--- a/tests/testthat/testCorrectForMemoryEffect.R
+++ b/tests/testthat/testCorrectForMemoryEffect.R
@@ -172,21 +172,21 @@ test_that("test memory corrected datasets", {
 test_that("test memory coefficients", {
 
   memCoeffExpected1 <- tibble::tribble(
-    ~`Inj Nr`, ~memoryCoeffD18O, ~memoryCoeffDD, ~A_vial1_d18O, ~A_vial1_dD, ~B_vial1_d18O, ~B_vial1_dD, ~C_vial1_d18O, ~C_vial1_dD,
-    # ------ / --------------- / ------------- / ------------ / ---------- / ------------ / ---------- / ------------ / -----------
-    1,         0.75,             0.76,           NA_real_,      NA_real_,    0.75,          0.71,        0.75,          0.81,
-    2,         1.0,              1.05,           NA_real_,      NA_real_,    1,             1.06,        1,             1.04,
-    3,         1.25,             1.18,           NA_real_,      NA_real_,    1.25,          1.22,        1.25,          1.15,
+    ~`Inj Nr`, ~A_vial1_d18O, ~A_vial1_dD, ~B_vial1_d18O, ~B_vial1_dD, ~C_vial1_d18O, ~C_vial1_dD, ~memoryCoeffD18O, ~memoryCoeffDD,
+    # ------ / ------------ / ---------- / ------------ / ---------- / ------------ / ---------- / --------------- / --------------
+    1,         NA_real_,      NA_real_,    0.75,          0.71,        0.75,          0.81,        0.75,             0.76,
+    2,         NA_real_,      NA_real_,    1,             1.06,        1,             1.04,        1.0,              1.05,
+    3,         NA_real_,      NA_real_,    1.25,          1.22,        1.25,          1.15,        1.25,             1.18
   )
 
   memCoeffExpected2 <- tibble::tribble(
-    ~`Inj Nr`, ~memoryCoeffD18O, ~memoryCoeffDD, ~A_vial1_d18O, ~A_vial1_dD, ~B_vial1_d18O, ~B_vial1_dD, ~C_vial1_d18O, ~C_vial1_dD,
-    # ------ / --------------- / ------------- / ------------ / ---------- / ------------ / ---------- / ------------ / -----------
-    1,         0.985,            0.992,          NA_real_,      NA_real_,    0.984,        0.992,        0.985,         0.992,
-    2,         0.990,            0.986,          NA_real_,      NA_real_,    0.990,        0.986,        0.990,         0.986,
-    3,         0.995,            0.992,          NA_real_,      NA_real_,    0.995,        0.992,        0.995,         0.992,
-    4,         1.0,              1.002,          NA_real_,      NA_real_,    1.000,        1.002,        1.000,         1.002,
-    5,         1.005,            1.007,          NA_real_,      NA_real_,    1.005,        1.007,        1.005,         1.007
+    ~`Inj Nr`, ~A_vial1_d18O, ~A_vial1_dD, ~B_vial1_d18O, ~B_vial1_dD, ~C_vial1_d18O, ~C_vial1_dD, ~memoryCoeffD18O, ~memoryCoeffDD,
+    # ------ / ------------ / ---------- / ------------ / ---------- / ------------ / ---------- / --------------- / --------------
+    1,         NA_real_,      NA_real_,    0.984,        0.992,        0.985,         0.992,       0.985,            0.992,
+    2,         NA_real_,      NA_real_,    0.990,        0.986,        0.990,         0.986,       0.990,            0.986,
+    3,         NA_real_,      NA_real_,    0.995,        0.992,        0.995,         0.992,       0.995,            0.992,
+    4,         NA_real_,      NA_real_,    1.000,        1.002,        1.000,         1.002,       1.0,              1.002,
+    5,         NA_real_,      NA_real_,    1.005,        1.007,        1.005,         1.007,       1.005,            1.007
   )
 
   actual1 <- correctForMemoryEffect(dataset1)

--- a/tests/testthat/testGroupStandardsInBlocks.R
+++ b/tests/testthat/testGroupStandardsInBlocks.R
@@ -12,7 +12,7 @@ test_that("test for dataframe with single row (contains standard)", {
   dfWithGroupedStandardsExpected <- tibble::tibble(
     `Identifier 1` = "STD_A",
     val = 3,
-    block = 1
+    block = 1L
   )
   dfWithGroupedStandardsActual <- groupStandardsInBlocks(df, config)
   
@@ -27,7 +27,7 @@ test_that("test for dataframe with single row (does not contain standard)", {
   dfWithGroupedStandardsExpected <- tibble::tibble(
     `Identifier 1` = "Probe",
     val = 3,
-    block = NA
+    block = NA_integer_
   )
   dfWithGroupedStandardsActual <- groupStandardsInBlocks(df, config)
   
@@ -42,7 +42,7 @@ test_that("test for dataframe with mulitple rows (first standard, then probe)", 
   dfWithGroupedStandardsExpected <- tibble::tibble(
     `Identifier 1` = c("STD_A", "Probe"),
     val = c(3, 7),
-    block = c(1, NA)
+    block = c(1L, NA)
   )
   dfWithGroupedStandardsActual <- groupStandardsInBlocks(df, config)
   
@@ -57,7 +57,7 @@ test_that("test for dataframe with mulitple rows (probe, standard, probe)", {
   dfWithGroupedStandardsExpected <- tibble::tibble(
     `Identifier 1` = c("Probe", "STD_A", "Probe"),
     val = c(1, 3, 7),
-    block = c(NA, 1, NA)
+    block = c(NA, 1L, NA)
   )
   dfWithGroupedStandardsActual <- groupStandardsInBlocks(df, config)
   
@@ -72,7 +72,7 @@ test_that("test for dataframe with mulitple rows (standard, probe, standard)", {
   dfWithGroupedStandardsExpected <- tibble::tibble(
     `Identifier 1` = c("STD_A", "Probe", "STD_B"),
     val = c(1, 3, 7),
-    block = c(1, NA, 2)
+    block = c(1L, NA, 2L)
   )
   dfWithGroupedStandardsActual <- groupStandardsInBlocks(df, config)
   
@@ -87,7 +87,7 @@ test_that("test for mulitple rows (standard, probe, standard, probe, standard)",
   dfWithGroupedStandardsExpected <- tibble::tibble(
     `Identifier 1` = c("STD_A", "Probe", "Probe", "STD_B", "STD_A", "Probe", "STD_A"),
     val = 1:7,
-    block = c(1, NA, NA, 2, 2, NA, 3)
+    block = c(1L, NA, NA, 2L, 2L, NA, 3L)
   )
   dfWithGroupedStandardsActual <- groupStandardsInBlocks(df, config)
   


### PR DESCRIPTION
This PR makes changes to comply with the new package versions of tibble 3.0.0 and dplyr 1.0.0.

Specifically, it implements the following changes:
* stricter rules concerning the setting of tibble column types (see [here](https://github.com/tidyverse/tibble/blob/master/NEWS.md#tibble-300)) which has become necessary now in the `groupStandardsInBlocks()` function with related tests updated;
* the dplyr function `group_keys()` is now used without the depracated grouping argument, instead grouping is done before by calling `group_by()`; this removes the generation of warnings;
* [dplyr 1.0.0 removal of `all.equal.tbl_df` method](https://www.tidyverse.org/blog/2020/04/dplyr-1-0-0-package-dev/) forces now exact match also of column and row positions when comparing tibbles with `testthat::expect_equal()`; tests and code have been adapted to comply with this update.
