### PR TITLE
Add acceptance tests

### DIFF
--- a/inst/extdata/config.yaml
+++ b/inst/extdata/config.yaml
@@ -10,7 +10,7 @@ include_standards_in_output: yes                  # Format of desired csv-file o
                                                   # flag = yes -> output standard and sample data in original order.
 
 # -------- data processing options --------
-average_over_inj: 2               # Specify number of injections to average for each sample to obtain final d18O, d2H etc. values:
+average_over_inj: 3               # Specify number of injections to average for each sample to obtain final d18O, d2H etc. values:
                                   # Pass single number to use the last n injections;
                                   # Pass x:y to use injections x to y. E.g. 2:4 to use injections 2, 3, and 4;
                                   # Pass "all" or -1 to use all injections.

--- a/tests/testthat/testProcessData.R
+++ b/tests/testthat/testProcessData.R
@@ -227,4 +227,16 @@ test_that("general acceptance is fulfilled", {
   } else {
     expect_lte(d, 0)
   }
+
+  # ----------------------------------
+  # BENCHMARK TEST:
+  # current performance should be kept
+  # ----------------------------------
+
+  # best current performance
+  benchmarkD18O <- 0.03
+  benchmarkDD   <- 0.4
+
+  expect_lte(rmsdD18OGood, benchmarkD18O)
+  expect_lte(rmsdDDGood, benchmarkDD)
 })


### PR DESCRIPTION
This PR does not introduce any updates to the code base, but, equally well important, it adds general acceptance tests, which check that the overall performace of the **piccr** processing is within acceptable limits, and therefore also remains so. These tests are based on evaluating and comparing the overall RMSD values for a **piccr** processing run performed on three exemplary real Picarro isotope measurement files.

The new tests include three general acceptance tests and one benchmark test:
* the general acceptance tests include
  - testing that the current package implementation of the **piccr** processing steps performs at least as good as the original but now outdated **piccr** command line version;
  - testing that the performance for applying the memory correction is better (lower RMSD) than processing without memory correction switched on;
  - testing that the performance for applying a drift correction is at least as good as when using no drift correction (i.e. only applying memory correction and calibrating the data).
* the benchmark test checks that future changes to the code base do not impair the performance of the currently best processing configuration for the three Picarro example files below the current state.

All these new tests are being passed; specifically:
* the current package implementation performs better than the original command line version;
* applying the memory correction is better than leaving it out;
* applying the drift correction is better than only memory-correcting and calibrating the data; here, drift correction method 2 (drift correction via "double-block calibration") performs better than method 1 ("simple drift correction");
* the benchmark test is passed (obviously).

This PR closes #8.